### PR TITLE
Mangadex cc

### DIFF
--- a/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
+++ b/src/all/mangadex/src/eu/kanade/tachiyomi/extension/all/mangadex/Mangadex.kt
@@ -54,7 +54,7 @@ abstract class Mangadex(
 
     override val baseUrl = "https://mangadex.cc"
 
-    private val cdnUrl = "https://s0.mangadex.cc"
+    private val cdnUrl = "https://mangadex.cc"
 
     override val supportsLatest = true
 


### PR DESCRIPTION
Hello. Can you check this update to fix the issue with the cdnUrl. It seems that MangaDex is not using cdn for now.

I also tried to use your given extension on the PR on the main repo, and it seems that image loading didn't work. I assume it is because of the cdnUrl.

Kindly test on your side if needed. I just updated your repo, since I can't compile the extension on my machine. I'm planning to use your modified extension if ever that you plan to build it again. Thanks.